### PR TITLE
Add VolatilityAdaptiveSpotV3 strategy and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# CryptoBot Setup
+
+This repository contains a sample Freqtrade strategy and configuration for spot trading
+using the **VolatilityAdaptiveSpotV3** strategy.
+
+## Quick start
+
+```bash
+# Python 3.12/3.13 environment
+python -m venv .venv && source .venv/bin/activate
+pip install -U pip
+pip install freqtrade==2025.7
+```
+
+## Initialize user data
+
+```bash
+freqtrade new-config --config user_data/config.json
+freqtrade new-strategy --strategy VolatilityAdaptiveSpotV3
+```
+
+Replace the generated files with the ones from this repository.
+
+## Download data
+
+```bash
+freqtrade download-data -c user_data/config.json --timeframes 1h --days 730
+```
+
+Feather files are stored under `user_data/data/<exchange>/spot/1h/`.
+
+## Sanity checks
+
+```bash
+freqtrade test-pairlist -c user_data/config.json
+freqtrade plot-dataframe -s VolatilityAdaptiveSpotV3 -c user_data/config.json -p ETH/USDT
+```
+
+## Backtest
+
+```bash
+freqtrade backtesting -s VolatilityAdaptiveSpotV3 -c user_data/config.json --export trades --timerange 2023-01-01-
+```
+
+Backtest results are exported into `user_data/backtest_results/`.
+
+## Hyperopt
+
+```bash
+freqtrade hyperopt -s VolatilityAdaptiveSpotV3 -c user_data/config.json --spaces buy sell roi stoploss trailing protections --timeframe 1h --epochs 300 --enable-protections
+```
+
+## Dry run
+
+```bash
+freqtrade trade -s VolatilityAdaptiveSpotV3 -c user_data/config.json
+```
+
+## UI / API (optional)
+
+Enable the `api_server` block in `user_data/config.json` and visit
+`http://127.0.0.1:8080/` locally. Do not expose the service publicly.
+
+## Troubleshooting
+
+* Ensure `TA-Lib` is installed if Freqtrade complains about missing dependencies.
+* Convert legacy data stores with `freqtrade convert-data --data-format-ohlcv feather`.
+* Validate exchange pair format using `freqtrade test-pairlist`.

--- a/config.json
+++ b/config.json
@@ -1,3 +1,0 @@
-{
-  "placeholder": true
-}

--- a/strategy.py
+++ b/strategy.py
@@ -1,1 +1,0 @@
-# Placeholder for strategy implementation

--- a/user_data/backtest_results/backtesting_error.log
+++ b/user_data/backtest_results/backtesting_error.log
@@ -1,0 +1,10 @@
+Traceback (most recent call last):
+  File "/root/.pyenv/versions/3.12.10/bin/freqtrade", line 3, in <module>
+    from freqtrade.main import main
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/freqtrade/main.py", line 17, in <module>
+    from freqtrade.commands import Arguments
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/freqtrade/commands/__init__.py", line 44, in <module>
+    from freqtrade.commands.pairlist_commands import start_test_pairlist
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/freqtrade/commands/pairlist_commands.py", line 4, in <module>
+    import rapidjson
+ModuleNotFoundError: No module named 'rapidjson'

--- a/user_data/config.json
+++ b/user_data/config.json
@@ -1,0 +1,41 @@
+{
+  "dry_run": true,
+  "stake_currency": "USDT",
+  "trading_mode": "spot",
+  "timeframe": "1h",
+  "max_open_trades": 1,
+  "pairlists": [
+    { "method": "StaticPairList" }
+  ],
+  "exchange": {
+    "name": "kraken",
+    "ccxt_config": { "enableRateLimit": true },
+    "pair_whitelist": ["ETH/USDT"]
+  },
+  "order_types": {
+    "entry": "limit",
+    "exit": "limit",
+    "emergencysell": "market",
+    "stoploss": "market"
+  },
+  "order_time_in_force": {
+    "entry": "GTC",
+    "exit": "GTC"
+  },
+  "unfilledtimeout": {
+    "entry": 20,
+    "exit": 10,
+    "unit": "minutes"
+  },
+  "dataformat_ohlcv": "feather",
+  "api_server": {
+    "enabled": false,
+    "listen_ip_address": "127.0.0.1",
+    "listen_port": 8080,
+    "enable_openapi": false,
+    "jwt_secret_key": "PLEASE_SET_A_SECRET",
+    "CORS_origins": [],
+    "username": "Freqtrader",
+    "password": "CHANGEME"
+  }
+}

--- a/user_data/strategies/VolatilityAdaptiveSpotV3.py
+++ b/user_data/strategies/VolatilityAdaptiveSpotV3.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from datetime import datetime
+from functools import reduce
+from typing import Any, Dict, Optional
+
+import numpy as np
+from freqtrade.persistence import Trade
+from freqtrade.strategy import IStrategy
+from pandas import DataFrame
+
+
+class VolatilityAdaptiveSpotV3(IStrategy):
+    """A basic spot strategy demonstrating Freqtrade interface v3."""
+
+    INTERFACE_VERSION = 3
+
+    can_short: bool = False
+    timeframe: str = "1h"
+    startup_candle_count: int = 200
+
+    minimal_roi: Dict[int, float] = {
+        0: 0.10,
+        720: 0.05,
+        1440: 0,
+    }
+
+    stoploss: float = -0.10
+    trailing_stop: bool = True
+    trailing_stop_positive: float = 0.02
+    trailing_stop_positive_offset: float = 0.04
+    trailing_only_offset_is_reached: bool = True
+
+    position_adjustment_enable: bool = True
+
+    protections = [
+        {"method": "CooldownPeriod", "value": 60},
+        {
+            "method": "MaxDrawdown",
+            "lookback_period": 1440,
+            "trade_limit": 20,
+            "stop_duration": 60,
+            "max_allowed_drawdown": 0.2,
+        },
+        {
+            "method": "StoplossGuard",
+            "lookback_period": 60,
+            "trade_limit": 2,
+            "stop_duration": 60,
+            "only_per_pair": True,
+        },
+    ]
+
+    order_types = {
+        "entry": "limit",
+        "exit": "limit",
+        "emergencysell": "market",
+        "stoploss": "market",
+    }
+
+    order_time_in_force = {"entry": "GTC", "exit": "GTC"}
+    unfilledtimeout = {"entry": 20, "exit": 10, "unit": "minutes"}
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: Dict[str, Any]) -> DataFrame:
+        dataframe["ema_fast"] = dataframe["close"].ewm(span=12, adjust=False).mean()
+        dataframe["ema_slow"] = dataframe["close"].ewm(span=26, adjust=False).mean()
+
+        delta = dataframe["close"].diff()
+        up = delta.clip(lower=0)
+        down = -delta.clip(upper=0)
+        roll_up = up.ewm(alpha=1 / 14, adjust=False).mean()
+        roll_down = down.ewm(alpha=1 / 14, adjust=False).mean()
+        rs = roll_up / roll_down
+        dataframe["rsi"] = 100 - (100 / (1 + rs))
+
+        hl = dataframe["high"] - dataframe["low"]
+        hc = (dataframe["high"] - dataframe["close"].shift()).abs()
+        lc = (dataframe["low"] - dataframe["close"].shift()).abs()
+        tr = reduce(np.maximum, [hl, hc, lc])
+        dataframe["atr"] = tr.ewm(span=14, adjust=False).mean()
+
+        dataframe["obv"] = (np.sign(dataframe["close"].diff()) * dataframe["volume"]).fillna(0).cumsum()
+        return dataframe
+
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: Dict[str, Any]) -> DataFrame:
+        dataframe.loc[
+            (
+                (dataframe["ema_fast"] > dataframe["ema_slow"]) &
+                (dataframe["rsi"].shift(1) < 30) &
+                (dataframe["rsi"] > dataframe["rsi"].shift(1)) &
+                (dataframe["obv"] > dataframe["obv"].rolling(5).mean())
+            ),
+            "enter_long",
+        ] = 1
+        return dataframe
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: Dict[str, Any]) -> DataFrame:
+        dataframe.loc[
+            (
+                (dataframe["ema_fast"] < dataframe["ema_slow"]) |
+                (dataframe["rsi"] > 70)
+            ),
+            "exit_long",
+        ] = 1
+        return dataframe
+
+    def confirm_trade_entry(
+        self,
+        pair: str,
+        order_type: str,
+        amount: float,
+        rate: float,
+        time_in_force: str,
+        **kwargs: Any,
+    ) -> bool:
+        return rate > 0
+
+    def confirm_trade_exit(
+        self,
+        pair: str,
+        trade: Trade,
+        order_type: str,
+        amount: float,
+        rate: float,
+        time_in_force: str,
+        **kwargs: Any,
+    ) -> bool:
+        return True
+
+    def custom_stoploss(
+        self,
+        pair: str,
+        trade: Trade,
+        current_time: datetime,
+        current_rate: float,
+        current_profit: float,
+        **kwargs: Any,
+    ) -> float:
+        dataframe = self.dp.get_analyzed_dataframe(pair, self.timeframe)
+        if dataframe is None or dataframe.empty:
+            return self.stoploss
+        atr = dataframe["atr"].iloc[-1]
+        if atr <= 0:
+            return self.stoploss
+        stop_price = current_rate - 2 * atr
+        return (stop_price - current_rate) / current_rate
+
+    def adjust_trade_position(
+        self,
+        trade: Trade,
+        current_time: datetime,
+        current_rate: float,
+        current_profit: float,
+        **kwargs: Any,
+    ) -> Optional[float]:
+        max_adds = 2
+        dca_spacing = 0.03
+        if trade.nr_of_successful_entries >= max_adds:
+            return None
+        if current_profit < -(dca_spacing * (trade.nr_of_successful_entries + 1)):
+            return trade.stake_amount
+        return None


### PR DESCRIPTION
## Summary
- add VolatilityAdaptiveSpotV3 spot strategy with ATR-based stops, DCA adjustments, and protections
- provide 2025-ready config and documentation
- include placeholder backtest results

## Testing
- `python -m py_compile user_data/strategies/VolatilityAdaptiveSpotV3.py`
- `ruff check user_data/strategies/VolatilityAdaptiveSpotV3.py`
- `freqtrade backtesting -c user_data/config.json -s VolatilityAdaptiveSpotV3 --timerange 2023-01-01- --export trades` *(fails: ModuleNotFoundError: No module named 'rapidjson')*

------
https://chatgpt.com/codex/tasks/task_e_6899b43076188328b119c24644c3e3e8