### PR TITLE
Align config and docs with current Freqtrade guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ using the **VolatilityAdaptiveSpotV3** strategy.
 # Python 3.12/3.13 environment
 python -m venv .venv && source .venv/bin/activate
 pip install -U pip
-pip install freqtrade==2025.7
+pip install freqtrade
 ```
+
+Refer to the [Freqtrade release notes](https://www.freqtrade.io/en/stable/releases/) to pin a specific version.
 
 ## Initialize user data
 
@@ -60,6 +62,21 @@ freqtrade trade -s VolatilityAdaptiveSpotV3 -c user_data/config.json
 
 Enable the `api_server` block in `user_data/config.json` and visit
 `http://127.0.0.1:8080/` locally. Do not expose the service publicly.
+
+Credentials (`jwt_secret_key`, `username`, `password`) should be provided via environment variables or a separate `user_data/secrets.json` file:
+
+```json
+{
+  "api_server": {
+    "jwt_secret_key": "YOUR_SECRET",
+    "username": "YOUR_USER",
+    "password": "YOUR_PASSWORD"
+  }
+}
+```
+
+Run the bot with both configs: `freqtrade trade -c user_data/config.json,user_data/secrets.json`
+
 
 ## Troubleshooting
 

--- a/user_data/config.json
+++ b/user_data/config.json
@@ -1,22 +1,29 @@
 {
   "dry_run": true,
   "stake_currency": "USDT",
+  "stake_amount": 100,
   "trading_mode": "spot",
   "timeframe": "1h",
   "max_open_trades": 1,
   "pairlists": [
-    { "method": "StaticPairList" }
+    {
+      "method": "StaticPairList"
+    }
   ],
   "exchange": {
     "name": "kraken",
-    "ccxt_config": { "enableRateLimit": true },
-    "pair_whitelist": ["ETH/USDT"]
+    "ccxt_config": {
+      "enableRateLimit": true
+    },
+    "pair_whitelist": [
+      "ETH/USDT"
+    ]
   },
   "order_types": {
     "entry": "limit",
     "exit": "limit",
-    "emergencysell": "market",
-    "stoploss": "market"
+    "stoploss": "market",
+    "emergency_exit": "market"
   },
   "order_time_in_force": {
     "entry": "GTC",
@@ -33,9 +40,6 @@
     "listen_ip_address": "127.0.0.1",
     "listen_port": 8080,
     "enable_openapi": false,
-    "jwt_secret_key": "PLEASE_SET_A_SECRET",
-    "CORS_origins": [],
-    "username": "Freqtrader",
-    "password": "CHANGEME"
+    "CORS_origins": []
   }
 }

--- a/user_data/strategies/VolatilityAdaptiveSpotV3.py
+++ b/user_data/strategies/VolatilityAdaptiveSpotV3.py
@@ -51,12 +51,6 @@ class VolatilityAdaptiveSpotV3(IStrategy):
         },
     ]
 
-    order_types = {
-        "entry": "limit",
-        "exit": "limit",
-        "emergencysell": "market",
-        "stoploss": "market",
-    }
 
     order_time_in_force = {"entry": "GTC", "exit": "GTC"}
     unfilledtimeout = {"entry": 20, "exit": 10, "unit": "minutes"}


### PR DESCRIPTION
## Summary
- add required stake_amount and rename deprecated emergencysell to emergency_exit
- centralize order type configuration and drop hard-coded API credentials
- refresh README with supported install instructions and secret handling

## Testing
- `python -m json.tool user_data/config.json`
- `python -m py_compile user_data/strategies/VolatilityAdaptiveSpotV3.py`


------
https://chatgpt.com/codex/tasks/task_e_6899db40187883288b6b1b2bfe866504