### PR TITLE
refactor: prepare strategies for freqtrade deployment

### DIFF
--- a/SimpleStrategy.py
+++ b/SimpleStrategy.py
@@ -1,24 +1,26 @@
-from freqtrade.strategy.interface import IStrategy
+from freqtrade.strategy import IStrategy
 from pandas import DataFrame
 
 
 class SimpleStrategy(IStrategy):
     """Basic EMA crossover strategy for Freqtrade."""
 
-    timeframe = '1h'
+    timeframe = "1h"
+    process_only_new_candles = True
+    startup_candle_count = 30
     minimal_roi = {"0": 0.05}
     stoploss = -0.1
     trailing_stop = False
 
-    def populate_indicators(self, df: DataFrame, metadata: dict) -> DataFrame:
-        df['ema_fast'] = df['close'].ewm(span=12, adjust=False).mean()
-        df['ema_slow'] = df['close'].ewm(span=26, adjust=False).mean()
-        return df
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe["ema_fast"] = dataframe["close"].ewm(span=12, adjust=False).mean()
+        dataframe["ema_slow"] = dataframe["close"].ewm(span=26, adjust=False).mean()
+        return dataframe
 
-    def populate_buy_trend(self, df: DataFrame, metadata: dict) -> DataFrame:
-        df.loc[(df['ema_fast'] > df['ema_slow']), 'buy'] = 1
-        return df
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[(dataframe["ema_fast"] > dataframe["ema_slow"]), "enter_long"] = 1
+        return dataframe
 
-    def populate_sell_trend(self, df: DataFrame, metadata: dict) -> DataFrame:
-        df.loc[(df['ema_fast'] < df['ema_slow']), 'sell'] = 1
-        return df
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[(dataframe["ema_fast"] < dataframe["ema_slow"]), "exit_long"] = 1
+        return dataframe

--- a/config.json
+++ b/config.json
@@ -3,10 +3,10 @@
   "stake_currency": "USDT",
   "stake_amount": "unlimited",
   "fiat_display_currency": "USD",
-  "dry_run": true,
-  "dry_run_wallet": 1000,
+  "dry_run": false,
   "trading_mode": "spot",
   "timeframe": "1h",
+  "process_only_new_candles": true,
   "max_open_trades": 5,
   "exchange": {
     "name": "binance",
@@ -18,5 +18,6 @@
   "pairlists": [
     { "method": "StaticPairList" }
   ],
+  "strategy_path": ".",
   "strategy": "SimpleStrategy"
 }

--- a/config_eth.json
+++ b/config_eth.json
@@ -3,10 +3,10 @@
   "stake_currency": "USDT",
   "stake_amount": "unlimited",
   "fiat_display_currency": "USD",
-  "dry_run": true,
-  "dry_run_wallet": 8000,
+  "dry_run": false,
   "trading_mode": "spot",
   "timeframe": "5m",
+  "process_only_new_candles": true,
   "max_open_trades": 5,
   "exchange": {
     "name": "kraken",
@@ -18,5 +18,6 @@
   "pairlists": [
     { "method": "StaticPairList" }
   ],
+  "strategy_path": ".",
   "strategy": "EthStrategy"
 }


### PR DESCRIPTION
## Summary
- update `SimpleStrategy` to use Freqtrade's entry/exit interface
- add a minimal `EthStrategy` implementing the Freqtrade API
- provide sample configs for both strategies
- add startup candle requirement and disable dry-run in configs

## Testing
- `python -m py_compile SimpleStrategy.py EthStrategy.py`
- `python -m json.tool config.json`
- `python -m json.tool config_eth.json`
- `pip install freqtrade` *(fails: `fatal error: ta-lib/ta_defs.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_689aee22210083288665e9a8390144e1